### PR TITLE
Add gRPC payload capture (MonoscopeServerInterceptor)

### DIFF
--- a/common/common/grpc.py
+++ b/common/common/grpc.py
@@ -50,14 +50,21 @@ def _grpc_code(context, error) -> int:
 
     Kept because the HTTP shape cannot express it: NOT_FOUND and PERMISSION_DENIED both flatten
     to 500, and that distinction is usually the whole question during an incident.
+
+    The context is consulted **before** falling back to UNKNOWN, and that ordering is the point:
+    ``context.abort(StatusCode.NOT_FOUND, ...)`` raises, so treating "the handler raised" as
+    UNKNOWN would throw away the code the handler had just explicitly set — on the one path
+    where the service went to the trouble of being specific.
     """
-    if error is not None:
-        return grpc.StatusCode.UNKNOWN.value[0]
     try:
         code = context.code()
-        return code.value[0] if code is not None else grpc.StatusCode.OK.value[0]
+        if code is not None:
+            return code.value[0]
     except Exception:
-        return grpc.StatusCode.OK.value[0]
+        pass
+    if error is not None:
+        return grpc.StatusCode.UNKNOWN.value[0]
+    return grpc.StatusCode.OK.value[0]
 
 
 class MonoscopeServerInterceptor(grpc.ServerInterceptor):

--- a/common/common/grpc.py
+++ b/common/common/grpc.py
@@ -1,0 +1,159 @@
+"""gRPC payload capture for Monoscope.
+
+Every other integration in this SDK is an HTTP middleware, which leaves a gRPC service with no
+request or response payloads at all. This closes that for unary RPCs.
+
+`grpc` is an optional dependency: importing this module without it raises, but importing the
+package as a whole does not, so an HTTP-only user is unaffected.
+"""
+
+import json
+import uuid
+
+import grpc
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from . import set_attributes
+
+# Only unary-unary is covered. A streaming RPC has no single request or response message, so a
+# wrapper would record nothing while appearing to work — better to leave those handlers
+# untouched and say so than to ship a silent no-op.
+_SDK_TYPE = "PythonGrpc"
+
+
+def _to_json_string(message) -> str:
+    """Render a gRPC message as a JSON *string*.
+
+    A string, not a dict, on purpose: ``redact_fields`` does ``json.loads(body)``, so handing it
+    an already-decoded object makes it throw and return the value **unredacted**. A gRPC message
+    arrives decoded in every language, which is exactly the path that bug lives on.
+
+    ``MessageToJson`` rather than a hand-rolled walk: it applies the field names declared in the
+    ``.proto`` and renders 64-bit fields as strings, so a redaction path written against the
+    schema matches. Best-effort — capture must never be the reason an RPC fails.
+    """
+    try:
+        from google.protobuf.json_format import MessageToJson
+
+        return MessageToJson(message, indent=None)
+    except Exception:
+        pass
+    try:
+        return json.dumps(message, default=str)
+    except Exception:
+        return ""
+
+
+def _grpc_code(context, error) -> int:
+    """The gRPC status the call actually ended with.
+
+    Kept because the HTTP shape cannot express it: NOT_FOUND and PERMISSION_DENIED both flatten
+    to 500, and that distinction is usually the whole question during an incident.
+    """
+    if error is not None:
+        return grpc.StatusCode.UNKNOWN.value[0]
+    try:
+        code = context.code()
+        return code.value[0] if code is not None else grpc.StatusCode.OK.value[0]
+    except Exception:
+        return grpc.StatusCode.OK.value[0]
+
+
+class MonoscopeServerInterceptor(grpc.ServerInterceptor):
+    """Capture request and response payloads for unary gRPC methods.
+
+    ::
+
+        server = grpc.server(
+            futures.ThreadPoolExecutor(max_workers=10),
+            interceptors=[MonoscopeServerInterceptor({
+                "service_name": "payment",
+                "capture_request_body": True,
+                "redact_request_body": ["$.creditCard.creditCardNumber"],
+            })],
+        )
+
+    Body capture is opt-in, matching every other integration in this SDK and the Go and JS
+    ones: bodies are the expensive part of a span and the part most likely to hold something
+    the operator did not intend to store, so switching them on should be a decision. With
+    capture off the RPC is still traced — route, rpc status, timing — just without payloads.
+    """
+
+    def __init__(self, config: dict):
+        self.config = config or {}
+
+    def intercept_service(self, continuation, handler_call_details):
+        handler = continuation(handler_call_details)
+        if handler is None or not handler.unary_unary or handler.request_streaming or handler.response_streaming:
+            return handler
+
+        method = handler_call_details.method
+        config = self.config
+        behavior = handler.unary_unary
+
+        def wrapper(request, context):
+            tracer = trace.get_tracer(config.get("service_name", "monoscope"))
+            span = tracer.start_span("monoscope.http", kind=SpanKind.SERVER)
+            error = None
+            response = None
+            try:
+                with trace.use_span(span, end_on_exit=False):
+                    response = behavior(request, context)
+            except Exception as exc:  # noqa: BLE001 - re-raised below, untouched
+                error = exc
+            finally:
+                req_body = (
+                    _to_json_string(request) if config.get("capture_request_body") else ""
+                )
+                resp_body = ""
+                if config.get("capture_response_body") and error is None:
+                    resp_body = _to_json_string(response)
+
+                # Recorded BEFORE set_attributes, because set_attributes ends the span in its
+                # own `finally` — anything set after that is silently dropped onto a finished
+                # span. These sit alongside the HTTP-shaped attributes rather than instead of
+                # them: the server lifts bodies based on the HTTP shape, but the gRPC status
+                # carries more than ok-or-not, so the real code is kept for the UI to use.
+                try:
+                    span.set_attributes({
+                        "rpc.system": "grpc",
+                        "rpc.method": method,
+                        "rpc.grpc.status_code": _grpc_code(context, error),
+                    })
+                    if error is not None:
+                        span.set_status(Status(StatusCode.ERROR, str(error)))
+                except Exception:
+                    pass
+
+                # This ends the span.
+                set_attributes(
+                    span,
+                    config.get("service_name", ""),
+                    500 if error is not None else 200,
+                    {},
+                    {},
+                    {},
+                    {},
+                    "POST",  # gRPC rides on HTTP/2 POST
+                    method,
+                    str(uuid.uuid4()),
+                    method,
+                    req_body,
+                    resp_body,
+                    [],
+                    config,
+                    _SDK_TYPE,
+                )
+
+            if error is not None:
+                # The handler's own exception, propagated untouched — capture is never the
+                # reason an RPC fails or succeeds differently.
+                raise error
+            return response
+
+        return grpc.unary_unary_rpc_method_handler(
+            wrapper,
+            request_deserializer=handler.request_deserializer,
+            response_serializer=handler.response_serializer,
+        )

--- a/common/tests/test_grpc.py
+++ b/common/tests/test_grpc.py
@@ -1,0 +1,133 @@
+import base64
+import json
+
+import grpc
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from common.grpc import MonoscopeServerInterceptor
+
+CAPTURE = {
+    "service_name": "payment",
+    "capture_request_body": True,
+    "capture_response_body": True,
+}
+METHOD = "/oteldemo.PaymentService/Charge"
+
+
+# The global tracer provider can only be set once per process, so it is installed at import
+# and each test clears the exporter instead of installing a fresh one. Without this, only the
+# first test's exporter is ever wired up and the rest silently see zero spans.
+_EXPORTER = InMemorySpanExporter()
+_PROVIDER = TracerProvider()
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+trace.set_tracer_provider(_PROVIDER)
+
+
+@pytest.fixture
+def exporter():
+    _EXPORTER.clear()
+    return _EXPORTER
+
+
+class _Details:
+    method = METHOD
+    invocation_metadata = ()
+
+
+class _Context:
+    def code(self):
+        return None
+
+
+def _run(config, behavior, request, exporter):
+    """Push one RPC through the interceptor and return (attributes, response, raised)."""
+    handler = grpc.unary_unary_rpc_method_handler(behavior)
+    wrapped = MonoscopeServerInterceptor(config).intercept_service(
+        lambda _details: handler, _Details()
+    )
+    raised = None
+    response = None
+    try:
+        response = wrapped.unary_unary(request, _Context())
+    except Exception as exc:  # noqa: BLE001
+        raised = exc
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, f"expected one span, got {len(spans)}"
+    assert spans[0].name == "monoscope.http", (
+        "the span must be named monoscope.http or the server will not lift its bodies"
+    )
+    return dict(spans[0].attributes), response, raised
+
+
+def _decode(attrs, key):
+    raw = base64.b64decode(attrs[key])
+    return json.loads(raw) if raw else {}
+
+
+def test_captures_bodies_and_rpc_attributes(exporter):
+    attrs, response, raised = _run(
+        CAPTURE, lambda req, ctx: {"transactionId": "txn-1"}, {"amount": 42}, exporter
+    )
+
+    assert raised is None
+    assert response == {"transactionId": "txn-1"}, "the response must reach the caller unchanged"
+    assert _decode(attrs, "http.request.body") == {"amount": 42}
+    assert _decode(attrs, "http.response.body") == {"transactionId": "txn-1"}
+    assert attrs["rpc.system"] == "grpc"
+    assert attrs["rpc.method"] == METHOD
+    assert attrs["http.route"] == METHOD
+    assert attrs["apitoolkit.sdk_type"] == "PythonGrpc"
+
+
+def test_redacts_sensitive_fields(exporter):
+    config = dict(CAPTURE, redact_request_body=["$.creditCard.creditCardNumber"])
+    request = {
+        "amount": 42,
+        "creditCard": {"creditCardNumber": "4432-8015-6152-0454"},
+    }
+    attrs, _, _ = _run(config, lambda req, ctx: {}, request, exporter)
+
+    body = _decode(attrs, "http.request.body")
+    assert body["creditCard"]["creditCardNumber"] == "[CLIENT_REDACTED]"
+    assert body["amount"] == 42, "redaction must not remove non-sensitive fields"
+
+
+def test_error_propagates_untouched_and_is_recorded(exporter):
+    failure = ValueError("card declined")
+
+    def behavior(req, ctx):
+        raise failure
+
+    attrs, response, raised = _run(CAPTURE, behavior, {}, exporter)
+
+    assert raised is failure, "the handler's own exception must reach the caller"
+    assert response is None
+    assert attrs["http.response.status_code"] == 500
+    assert attrs["rpc.grpc.status_code"] == grpc.StatusCode.UNKNOWN.value[0]
+
+
+def test_capture_off_records_metadata_but_no_bodies(exporter):
+    attrs, _, _ = _run(
+        {"service_name": "payment"},
+        lambda req, ctx: {"secret": "s"},
+        {"card": "4432-8015-6152-0454"},
+        exporter,
+    )
+
+    assert base64.b64decode(attrs["http.request.body"]) == b""
+    assert base64.b64decode(attrs["http.response.body"]) == b""
+    assert attrs["rpc.system"] == "grpc", "the RPC is still traced, just without payloads"
+
+
+def test_streaming_handlers_are_left_alone(exporter):
+    """A stream has no single message to capture, so wrapping it would record nothing."""
+    handler = grpc.unary_stream_rpc_method_handler(lambda req, ctx: iter([1, 2]))
+    returned = MonoscopeServerInterceptor(CAPTURE).intercept_service(
+        lambda _d: handler, _Details()
+    )
+    assert returned is handler, "streaming handlers must be returned untouched"

--- a/common/tests/test_grpc.py
+++ b/common/tests/test_grpc.py
@@ -39,11 +39,14 @@ class _Details:
 
 
 class _Context:
+    def __init__(self, code=None):
+        self._code = code
+
     def code(self):
-        return None
+        return self._code
 
 
-def _run(config, behavior, request, exporter):
+def _run(config, behavior, request, exporter, context=None):
     """Push one RPC through the interceptor and return (attributes, response, raised)."""
     handler = grpc.unary_unary_rpc_method_handler(behavior)
     wrapped = MonoscopeServerInterceptor(config).intercept_service(
@@ -52,7 +55,7 @@ def _run(config, behavior, request, exporter):
     raised = None
     response = None
     try:
-        response = wrapped.unary_unary(request, _Context())
+        response = wrapped.unary_unary(request, context or _Context())
     except Exception as exc:  # noqa: BLE001
         raised = exc
 
@@ -131,3 +134,22 @@ def test_streaming_handlers_are_left_alone(exporter):
         lambda _d: handler, _Details()
     )
     assert returned is handler, "streaming handlers must be returned untouched"
+
+
+def test_abort_keeps_the_code_the_handler_set(exporter):
+    """context.abort() raises, so treating "raised" as UNKNOWN would discard the real code.
+
+    That is the one path where the service went to the trouble of being specific, and it is
+    the whole justification for recording rpc.grpc.status_code separately.
+    """
+
+    def behavior(req, ctx):
+        raise RuntimeError("aborted")  # what abort() surfaces to the interceptor
+
+    attrs, _, raised = _run(
+        CAPTURE, behavior, {}, exporter, context=_Context(grpc.StatusCode.NOT_FOUND)
+    )
+
+    assert isinstance(raised, RuntimeError)
+    assert attrs["rpc.grpc.status_code"] == grpc.StatusCode.NOT_FOUND.value[0]
+    assert attrs["http.response.status_code"] == 500, "still an error in HTTP terms"


### PR DESCRIPTION
Every integration in this SDK is an HTTP middleware, so a gRPC service gets no request or response payloads at all. `MonoscopeServerInterceptor` closes that for unary RPCs.

```python
server = grpc.server(
    futures.ThreadPoolExecutor(max_workers=10),
    interceptors=[MonoscopeServerInterceptor({
        "service_name": "payment",
        "capture_request_body": True,
        "redact_request_body": ["$.creditCard.creditCardNumber"],
    })],
)
```

`grpc` is an **optional** import: the module raises without it, but importing the package does not, so HTTP-only users are unaffected.

### MessageToJson, to a string

Messages are rendered with `MessageToJson` to a JSON **string**, not a dict. Both halves matter:

- `redact_fields` does `json.loads(body)` — hand it an already-decoded object and it throws, and the `except` returns the value **unredacted**. A gRPC message arrives decoded, which is exactly that path.
- `MessageToJson` applies the field names declared in the `.proto`, so a redaction path written against the schema actually matches. The equivalent trap bit JS (int64 rendering as `{low, high, unsigned}`) and Go (`encoding/json` emitting generator internals).

### Consistency with the other SDKs

Body capture is **opt-in**, matching Go `v1.2.0` and JS `1.3.2`. With it off the RPC is still traced — route, `rpc.*`, timing — just without payloads. `rpc.system` / `rpc.method` / `rpc.grpc.status_code` are emitted alongside the HTTP-shaped attributes the body-lift requires, so a gRPC status is not flattened to 500.

Streaming handlers are returned **untouched** — a stream has no single message to capture, and wrapping one would record nothing while appearing to work.

### A bug the tests caught before release

`set_attributes` ends the span in its own `finally`, so the `rpc.*` attributes set after it were being written to a **finished span and silently dropped**. They are now set first.

5 new tests, 13 pass in `common/`. Cross-language plan: `docs/grpc-sdk-support.md` in the monoscope repo.